### PR TITLE
🪲 [Fix]: Fix linter settings and docs

### DIFF
--- a/.github/PSModule.yml
+++ b/.github/PSModule.yml
@@ -19,3 +19,12 @@ Test:
 # Build:
 #   Docs:
 #     Skip: true
+Linter:
+  env:
+    VALIDATE_BIOME_FORMAT: false
+    VALIDATE_BIOME_LINT: false
+    VALIDATE_GITHUB_ACTIONS_ZIZMOR: false
+    VALIDATE_JSCPD: false
+    VALIDATE_JSON_PRETTIER: false
+    VALIDATE_MARKDOWN_PRETTIER: false
+    VALIDATE_YAML_PRETTIER: false

--- a/.github/PSModule.yml
+++ b/.github/PSModule.yml
@@ -19,3 +19,13 @@ Test:
 # Build:
 #   Docs:
 #     Skip: true
+
+Linter:
+  env:
+    VALIDATE_BIOME_FORMAT: false
+    VALIDATE_BIOME_LINT: false
+    VALIDATE_GITHUB_ACTIONS_ZIZMOR: false
+    VALIDATE_JSCPD: false
+    VALIDATE_JSON_PRETTIER: false
+    VALIDATE_MARKDOWN_PRETTIER: false
+    VALIDATE_YAML_PRETTIER: false

--- a/.github/linters/.markdown-lint.yml
+++ b/.github/linters/.markdown-lint.yml
@@ -8,18 +8,19 @@
 ###############
 # Rules by id #
 ###############
-MD004: false                  # Unordered list style
+MD004: false # Unordered list style
 MD007:
-  indent: 2                   # Unordered list indentation
+  indent: 2 # Unordered list indentation
 MD013:
-  line_length: 808            # Line length
+  line_length: 808 # Line length
+MD024: false # no-duplicate-heading, INPUTS and OUTPUTS _can_ be the same item
 MD026:
-  punctuation: ".,;:!。，；:"  # List of not allowed
-MD029: false                  # Ordered list item prefix
-MD033: false                  # Allow inline HTML
-MD036: false                  # Emphasis used instead of a heading
+  punctuation: '.,;:!。，；:' # List of not allowed
+MD029: false # Ordered list item prefix
+MD033: false # Allow inline HTML
+MD036: false # Emphasis used instead of a heading
 
 #################
 # Rules by tags #
 #################
-blank_lines: false  # Error on blank lines
+blank_lines: false # Error on blank lines

--- a/src/functions/public/Set-PSModuleTest.ps1
+++ b/src/functions/public/Set-PSModuleTest.ps1
@@ -3,6 +3,9 @@
         .SYNOPSIS
         Performs tests on a module.
 
+        .DESCRIPTION
+        Performs tests on a module.
+
         .EXAMPLE
         Test-PSModule -Name 'World'
 


### PR DESCRIPTION
This pull request introduces several configuration and documentation updates aimed at improving linting behavior and documentation clarity. The most notable changes include adjustments to markdown linting rules, disabling specific linter validations in the GitHub workflow, and enhancing the inline documentation for a PowerShell script.

**Linting and Workflow Configuration:**

* Disabled several linter validations (e.g., Biome, JSCPD, Prettier for JSON/Markdown/YAML, and GitHub Actions Zizmor) in the `Linter` section of `.github/PSModule.yml` to streamline CI checks.
* Updated `.github/linters/.markdown-lint.yml` to:
  - Explicitly disable the `MD024` rule (no-duplicate-heading) to allow repeated headings like INPUTS and OUTPUTS.
  - Fix punctuation formatting for `MD026`.

**Documentation Improvements:**

* Added a `.DESCRIPTION` section to the `Set-PSModuleTest.ps1` script to improve its inline documentation.